### PR TITLE
デカい画像は必要ない

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -17,7 +17,7 @@
     <meta property="og:image" content="{{ '/img/ogp.png' | url | absoluteUrl(metadata.url)}}" />
     <meta property="og:description" content="{{ description or metadata.description }}" />
 
-    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="{{ metadata.author.twitter }}" />
     <meta name="twitter:creator" content="{{ metadata.author.twitter }}" />
     <meta name="twitter:title" content="{{ title or metadata.title }}" />


### PR DESCRIPTION
Twitter カードの画像を小さくします